### PR TITLE
Fix domain serialization in SOCKS client request

### DIFF
--- a/lib/src/client/socks_client.dart
+++ b/lib/src/client/socks_client.dart
@@ -194,8 +194,7 @@ class SocksSocket with StreamMixin<Uint8List>, SocketMixin, ByteReader {
         0x00, // Reserved
         addressType.byte,
         // Encoding address, if domain adding length at the beginning.
-        if (addressType == AddressType.domain) rawAddress.length,
-        ...rawAddress,
+        ...(addressType == AddressType.domain ? [rawAddress.length - 1, ...rawAddress.sublist(0, rawAddress.length - 1)] : rawAddress),
         // Encoding port as big endian short.
         (targetPort & 0xff00) >> 8, targetPort & 0x00ff,
       ]),


### PR DESCRIPTION
SocksTCPClient.assignToHttpClientWithSecureOptions does
```
        final client = SocksTCPClient.connect(
          proxies,
          InternetAddress(uri.host, type: InternetAddressType.unix),
          uri.port,
        );
```

Which adds a 0 to the end of `uri.host`
```
InternetAddress('example.com', type: InternetAddressType.unix).rawAddress
[101, 120, 97, 109, 112, 108, 101, 46, 99, 111, 109, 0]
```

Resulting in the serialized domain in the SOCKS request to be
```
[12, 101, 120, 97, 109, 112, 108, 101, 46, 99, 111, 109, 0]
```

instead of
```
[11, 101, 120, 97, 109, 112, 108, 101, 46, 99, 111, 109]
```

Some servers try to resolve 'example.com\0' which will fail.
